### PR TITLE
[Add] deviltux.thedev.id subdomain

### DIFF
--- a/subdomains.json
+++ b/subdomains.json
@@ -58,6 +58,7 @@
   "dendydharmawan": "dendydharmawan.vercel.app",
   "descendo": "hayden-droid.github.io",
   "devbox": "devbox-nu.vercel.app/",
+  "deviltux": "duraki.github.io",
   "devinesia": "devinesia.github.io",
   "dhruvil": "dhruvilmoradiya.github.io",
   "dhyan99": "d99-1.github.io",


### PR DESCRIPTION
Added a new CNAME entry via `deviltux` alias, pointing to my [blog](https://duraki.github.io)