### PR TITLE
Add romw314 to subdomains.json

### DIFF
--- a/subdomains.json
+++ b/subdomains.json
@@ -171,6 +171,7 @@
   "rogerp": "rogerpanza.github.io",
   "rohmadkur": "rohmadkur.netlify.app",
   "rojan": "rojangamingyt.github.io",
+  "romw314": "romw314.github.io",
   "roshan": "roshan1337d.github.io",
   "rumahzen": "mzaini30.github.io/rumah-zen",
   "saksham": "oshekharo.github.io",


### PR DESCRIPTION
Added romw314 pointing to romw314.github.io.
I allow edits by maintainers so you can fix it if needed.

And a question ❓ Can I add also an alias for chess-no-25.vercel.app in another PR or there is 1 subdomain/user.

I starred this already: https://github.com/romw314?tab=stars