### PR TITLE
Add quadeer.thedev.id

### DIFF
--- a/subdomains.json
+++ b/subdomains.json
@@ -155,6 +155,7 @@
   "ponomarevlad": "ponomarevlad.github.io",
   "pranshu05": "pranshu05.github.io",
   "proudmuslim": "proudmuslim-dev.github.io",
+  "quadeer": "quadeer.pages.dev",
   "quartz": "chrissquartz.cf",
   "rahuletto": "rahuletto.github.io",
   "rahulsya": "rahulsya.netlify.app",
@@ -167,7 +168,7 @@
   "richie": "richiesuper.github.io",
   "rivaldi": "bagusrivaldi.github.io",
   "rizwan": "rizwan-kh.github.io",
-  "robsd": "robsd.pages.dev"
+  "robsd": "robsd.pages.dev",
   "rogerp": "rogerpanza.github.io",
   "rohmadkur": "rohmadkur.netlify.app",
   "rojan": "rojangamingyt.github.io",


### PR DESCRIPTION
This pull request is to add `quadeer.thedev.id` and it also addresses an issue in the `subdomains.json`  file and adds a new subdomain entry.

Details
1. Added `"quadeer": "quadeer.pages.dev"` in json file
2. Fixed JSON Syntax Error:

Corrected a missing comma at line 170 in the `subdomains.json` file. This syntax error was preventing the successful execution of the `npm run sort` command.


