### PR TITLE
Ajout de msz.is-a.dev

### DIFF
--- a/subdomains.json
+++ b/subdomains.json
@@ -220,5 +220,7 @@
   "zen": "zen-sveltekit.vercel.app",
   "zh": "zh.github.io",
   "zuhaib": "powrhouseofthecell.github.io",
-  "zvqle": "zvqlesrealm.vercel.app"
+  "zvqle": "zvqlesrealm.vercel.app",
+  "msz": "medix91.github.io/msz-resume"
+
 }

--- a/subdomains.json
+++ b/subdomains.json
@@ -102,7 +102,7 @@
   "ibrahim": "minidevz.github.io",
   "icm": "icm185.github.io",
   "ihsan": "ihsanfikri.github.io",
-  "ichsan": "ichsanputr.github.io"
+  "ichsan": "ichsanputr.github.io",
   "ik3": "ik3.github.io",
   "ilham25": "ilham25.github.io",
   "imjustchew": "imjustchew.vercel.app",
@@ -170,7 +170,7 @@
   "richie": "richiesuper.github.io",
   "rivaldi": "bagusrivaldi.github.io",
   "rizwan": "rizwan-kh.github.io",
-  "robsd": "robsd.pages.dev"
+  "robsd": "robsd.pages.dev",
   "rogerp": "rogerpanza.github.io",
   "rohmadkur": "rohmadkur.netlify.app",
   "rojan": "rojangamingyt.github.io",


### PR DESCRIPTION
Ajout du sous-domaine msz.is-a.dev pour pointer vers medix91.github.io/msz-resum