### PR TITLE
Added awscloudclubskku.thedev.id and dtnnd3w7efkr.thedev.id subdomains

### DIFF
--- a/subdomains.json
+++ b/subdomains.json
@@ -32,6 +32,7 @@
   "asy": "asy.github.io",
   "avileforsure": "avileforsure.github.io",
   "avyanshralph": "avyansh0001.github.io",
+  "awscloudclubskku": "ghs.google.com",
   "ayush": "iddev5.github.io",
   "bakunya": "bakunya.pages.dev",
   "barbarbar338": "barbarbar338.fly.dev",
@@ -72,6 +73,7 @@
   "dontkill": "dontkill.github.io",
   "dook": "portfolio-beta-five-72.vercel.app",
   "drmonocle": "monocledr.github.io",
+  "dtnnd3w7efkr": "gv-ipocmgbwtsunn3.dv.googlehosted.com",
   "duckinc": "0e139846-5714-4001-a085-6fe24b982068.id.repl.co",
   "dvd": "arnon001.github.io/dvd",
   "edrea": "edrea.netlify.app",
@@ -100,9 +102,9 @@
   "hung": "hunghg-portfolio.vercel.app",
   "hycord": "hycord.github.io",
   "ibrahim": "minidevz.github.io",
+  "ichsan": "ichsanputr.github.io",
   "icm": "icm185.github.io",
   "ihsan": "ihsanfikri.github.io",
-  "ichsan": "ichsanputr.github.io",
   "ik3": "ik3.github.io",
   "ilham25": "ilham25.github.io",
   "imjustchew": "imjustchew.vercel.app",
@@ -220,7 +222,5 @@
   "zen": "zen-sveltekit.vercel.app",
   "zh": "zh.github.io",
   "zuhaib": "powrhouseofthecell.github.io",
-  "zvqle": "zvqlesrealm.vercel.app",
-  "awscloudclubskku": "ghs.google.com",
-  "dtnnd3w7efkr": "gv-ipocmgbwtsunn3.dv.googlehosted.com"
+  "zvqle": "zvqlesrealm.vercel.app"
 }

--- a/subdomains.json
+++ b/subdomains.json
@@ -102,7 +102,7 @@
   "ibrahim": "minidevz.github.io",
   "icm": "icm185.github.io",
   "ihsan": "ihsanfikri.github.io",
-  "ichsan": "ichsanputr.github.io"
+  "ichsan": "ichsanputr.github.io",
   "ik3": "ik3.github.io",
   "ilham25": "ilham25.github.io",
   "imjustchew": "imjustchew.vercel.app",
@@ -170,7 +170,7 @@
   "richie": "richiesuper.github.io",
   "rivaldi": "bagusrivaldi.github.io",
   "rizwan": "rizwan-kh.github.io",
-  "robsd": "robsd.pages.dev"
+  "robsd": "robsd.pages.dev",
   "rogerp": "rogerpanza.github.io",
   "rohmadkur": "rohmadkur.netlify.app",
   "rojan": "rojangamingyt.github.io",

--- a/subdomains.json
+++ b/subdomains.json
@@ -220,5 +220,7 @@
   "zen": "zen-sveltekit.vercel.app",
   "zh": "zh.github.io",
   "zuhaib": "powrhouseofthecell.github.io",
-  "zvqle": "zvqlesrealm.vercel.app"
+  "zvqle": "zvqlesrealm.vercel.app",
+  "awscloudclubskku": "ghs.google.com",
+  "dtnnd3w7efkr": "gv-ipocmgbwtsunn3.dv.googlehosted.com"
 }


### PR DESCRIPTION
This pull request adds two new subdomains to thedev.id:

- `awscloudclubskku.thedev.id`: This subdomain will be used to link to the official blog website of the AWS Cloud Club at Sungkyunkwan University, which is hosted on Blogger (https://awscloudclubskku.blogspot.com/), in order to provide a convenient and memorable URL for the organization's online presence.
- `dtnnd3w7efkr.thedev.id`: This subdomain is a secondary CNAME record, which is mandatory for successfully linking a Blogger-hosted website with a custom domain. Blogger requires this additional CNAME for domain verification and proper functionality.

This PR also includes a minor cleanup by resolving existing trailing commas within the `subdomains.json` file, ensuring proper JSON formatting and avoids potential parsing issues.