### PR TITLE
Adding owgames subdomain for GitHub Pages

### DIFF
--- a/subdomains.json
+++ b/subdomains.json
@@ -220,5 +220,6 @@
   "zen": "zen-sveltekit.vercel.app",
   "zh": "zh.github.io",
   "zuhaib": "powrhouseofthecell.github.io",
-  "zvqle": "zvqlesrealm.vercel.app"
+  "zvqle": "zvqlesrealm.vercel.app",
+  "owgames": "ow-games.github.io"
 }

--- a/subdomains.json
+++ b/subdomains.json
@@ -148,6 +148,7 @@
   "o": "owlg.github.io",
   "ocloo": "dev0cloo.github.io/portfolio/",
   "op": "op-bot.github.io",
+  "owgames": "ow-games.github.io",
   "paban": "pabanjyoti.github.io",
   "pablo": "itspablo.glitch.me",
   "penguin": "bcyayay14.github.io",
@@ -220,6 +221,5 @@
   "zen": "zen-sveltekit.vercel.app",
   "zh": "zh.github.io",
   "zuhaib": "powrhouseofthecell.github.io",
-  "zvqle": "zvqlesrealm.vercel.app",
-  "owgames": "ow-games.github.io"
+  "zvqle": "zvqlesrealm.vercel.app"
 }


### PR DESCRIPTION
Requesting the subdomain "owgames.thedev.id" for my Unity/C# projects.

GitHub Pages is already configured with this subdomain in the CNAME file, pointing to my repository at "ow-games.github.io".

Thank you for reviewing and merging this request!