### PR TITLE
Add vinits.thedev.id -> vsconnect.duckdns.org

### DIFF
--- a/subdomains.json
+++ b/subdomains.json
@@ -220,5 +220,6 @@
   "zen": "zen-sveltekit.vercel.app",
   "zh": "zh.github.io",
   "zuhaib": "powrhouseofthecell.github.io",
-  "zvqle": "zvqlesrealm.vercel.app"
+  "zvqle": "zvqlesrealm.vercel.app",
+  "vinits": "vsconnect.duckdns.org"
 }


### PR DESCRIPTION
Add vinits.thedev.id pointing to vsconnect.duckdns.org

- GitHub username: vinit2512
- Site host: vsconnect.duckdns.org
- Live site (where it will point after merge): http://vsconnect.duckdns.org

I added the mapping and created this branch. Please let me know if any formatting or sorting changes are needed.