### PR TITLE
Add aiboard.thedev.id for AI Dashboard

### DIFF
--- a/subdomains.json
+++ b/subdomains.json
@@ -10,6 +10,7 @@
   "ahmadhayyan": "ahmadhayyan.github.io",
   "ahmedazhar05": "ahmedazhar05.github.io",
   "ahskript": "ahskript.github.io",
+  "aiboard": "ai-dashboard.unknown-onesecondthird.workers.dev",
   "ali": "hmd-ali.github.io",
   "alicedtrh": "thedevid.alicedtrh.xyz",
   "alvndrz": "0218257c-25a0-4d30-a09b-577b62b101ee.id.repl.co",
@@ -100,9 +101,9 @@
   "hung": "hunghg-portfolio.vercel.app",
   "hycord": "hycord.github.io",
   "ibrahim": "minidevz.github.io",
+  "ichsan": "ichsanputr.github.io",
   "icm": "icm185.github.io",
   "ihsan": "ihsanfikri.github.io",
-  "ichsan": "ichsanputr.github.io"
   "ik3": "ik3.github.io",
   "ilham25": "ilham25.github.io",
   "imjustchew": "imjustchew.vercel.app",
@@ -170,7 +171,7 @@
   "richie": "richiesuper.github.io",
   "rivaldi": "bagusrivaldi.github.io",
   "rizwan": "rizwan-kh.github.io",
-  "robsd": "robsd.pages.dev"
+  "robsd": "robsd.pages.dev",
   "rogerp": "rogerpanza.github.io",
   "rohmadkur": "rohmadkur.netlify.app",
   "rojan": "rojangamingyt.github.io",


### PR DESCRIPTION
Adding `aiboard.thedev.id` subdomain for the AI Usage Dashboard deployed on Cloudflare Workers.

- Subdomain: `aiboard`
- CNAME target: `ai-dashboard.unknown-onesecondthird.workers.dev`
- Purpose: AI Usage Dashboard