### PR TITLE
add “bestspark” subdomain

### DIFF
--- a/subdomains.json
+++ b/subdomains.json
@@ -36,6 +36,7 @@
   "bakunya": "bakunya.pages.dev",
   "barbarbar338": "barbarbar338.fly.dev",
   "bblog": "bblog.pages.dev",
+  "bestspark": "vps.bestspark.org",
   "bipul": "bipuldey-portfolio.netlify.app",
   "blockhead": "xBLOCK-HEADx.github.io",
   "blog-halip26": "blog-halip26.vercel.app",


### PR DESCRIPTION
This should be in the correct spot alphabetically. If it isn’t, my bad.